### PR TITLE
Bump surge version to remove security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "license": "MIT",
   "devDependencies": {
     "serve": "^1.4.0",
-    "surge": "^0.18.0"
+    "surge": "^0.21.3"
   }
 }


### PR DESCRIPTION
I tested it locally and it works with the new version without a problem