### PR TITLE
fix: prepend const to `markdown`

### DIFF
--- a/.github/actions/update-upcoming-events.js
+++ b/.github/actions/update-upcoming-events.js
@@ -54,7 +54,7 @@ async function run() {
         .join("\n")
     : "There are currently no upcoming events scheduled.";
 
-  markdown = `## Join lunch.js on ${dateNextEvent.format(
+  const markdown = `## Join lunch.js on ${dateNextEvent.format(
     "MMM d, YYYY [at] H:mma"
   )}
   


### PR DESCRIPTION
### Summary

Paired with @gr2m and caught this while reviewing the `update-upcoming-events.js` -- this prepends `const` to `markdown` for submitting the final copy for an updated README.